### PR TITLE
Improve stamping incomming stanzas with correct `from` attribute

### DIFF
--- a/src/main/java/tigase/server/Packet.java
+++ b/src/main/java/tigase/server/Packet.java
@@ -109,7 +109,7 @@ public class Packet {
 	private JID stanzaTo = null;
 	private StanzaType type;
 	private String stableId = null;
-	private JID serverAuthorisedStanzaFrom = null;
+	private Optional<JID> serverAuthorisedStanzaFrom = Optional.empty();
 
 	/**
 	 * Method trims {@link Element} stanza to 1024 characters and returns String representation of the element
@@ -616,7 +616,7 @@ public class Packet {
 	@Deprecated
 	@TigaseDeprecated(since = "8.2.0", removeIn = "9.0.0")
 	public Optional<JID> getServerAuthorisedStanzaFrom() {
-		return Optional.ofNullable(serverAuthorisedStanzaFrom);
+		return serverAuthorisedStanzaFrom;
 	}
 
 	/**
@@ -634,7 +634,7 @@ public class Packet {
 	@Deprecated
 	@TigaseDeprecated(since = "8.2.0", removeIn = "9.0.0")
 	public void setServerAuthorisedStanzaFrom(JID serverAuthorisedStanzaFrom) {
-		this.serverAuthorisedStanzaFrom = serverAuthorisedStanzaFrom;
+		this.serverAuthorisedStanzaFrom = Optional.ofNullable(serverAuthorisedStanzaFrom);
 		this.packetToString = null;
 		this.packetToStringSecure = null;
 	}

--- a/src/main/java/tigase/server/Packet.java
+++ b/src/main/java/tigase/server/Packet.java
@@ -17,6 +17,7 @@
  */
 package tigase.server;
 
+import tigase.annotations.TigaseDeprecated;
 import tigase.util.stringprep.TigaseStringprepException;
 import tigase.xml.Element;
 import tigase.xmpp.StanzaType;
@@ -24,6 +25,7 @@ import tigase.xmpp.jid.JID;
 
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -107,6 +109,7 @@ public class Packet {
 	private JID stanzaTo = null;
 	private StanzaType type;
 	private String stableId = null;
+	private JID serverAuthorisedStanzaFrom = null;
 
 	/**
 	 * Method trims {@link Element} stanza to 1024 characters and returns String representation of the element
@@ -599,6 +602,44 @@ public class Packet {
 	}
 
 	/**
+	 * Method returns JID from-address that was authenticated and bound to user session.
+	 *
+	 * This is a helper method that facilitates and improve maintaining correct stanza from when
+	 * communicating between ClientConnectionManager and SessionManager.
+	 *
+	 * This is a temporary solution! In version 9.0, after reviewing the APIs and correcting clustering strategy
+	 * packets incomming in (Client) Connection Managers should already have correct 'from' attribute in stanzas
+	 * set in {@code tigase.server.xmppclient.ClientConnectionManager#processSocketData(tigase.xmpp.XMPPIOService)}.
+	 *
+	 * @return {@code Optional} that may contain user JID if the session was already authorised.
+	 */
+	@Deprecated
+	@TigaseDeprecated(since = "8.2.0", removeIn = "9.0.0")
+	public Optional<JID> getServerAuthorisedStanzaFrom() {
+		return Optional.ofNullable(serverAuthorisedStanzaFrom);
+	}
+
+	/**
+	 * Method used to set JID from-address that was authenticated and bound to user session.
+	 *
+	 * This is a helper method that facilitates and improve maintaining correct stanza from when
+	 * communicating between ClientConnectionManager and SessionManager.
+	 *
+	 * This is a temporary solution! In version 9.0, after reviewing the APIs and correcting clustering strategy
+	 * packets incomming in (Client) Connection Managers should already have correct 'from' attribute in stanzas
+	 * set in {@code tigase.server.xmppclient.ClientConnectionManager#processSocketData(tigase.xmpp.XMPPIOService)}.
+	 *
+	 * @param serverAuthorisedStanzaFrom
+	 */
+	@Deprecated
+	@TigaseDeprecated(since = "8.2.0", removeIn = "9.0.0")
+	public void setServerAuthorisedStanzaFrom(JID serverAuthorisedStanzaFrom) {
+		this.serverAuthorisedStanzaFrom = serverAuthorisedStanzaFrom;
+		this.packetToString = null;
+		this.packetToStringSecure = null;
+	}
+
+	/**
 	 * Method returns a set of all processor IDs which skipped processing packets.
 	 *
 	 * @return a <code>Set</code> of stanza processor IDs which skipped the packet.
@@ -1071,7 +1112,7 @@ public class Packet {
 			packetToString = calcToString(elemData);
 		}
 
-		return "from=" + packetFrom + ", to=" + packetTo + packetToString;
+		return "from=" + packetFrom + ", to=" + packetTo + ", serverAuthorisedStanzaFrom=" + getServerAuthorisedStanzaFrom() + packetToString;
 	}
 
 	/**
@@ -1122,7 +1163,7 @@ public class Packet {
 				packetToStringSecure = calcToString(elemData);
 			}
 
-			return "from=" + packetFrom + ", to=" + packetTo + packetToStringSecure;
+			return "from=" + packetFrom + ", to=" + packetTo + ", serverAuthorisedStanzaFrom=" + getServerAuthorisedStanzaFrom() + packetToStringSecure;
 		}
 	}
 

--- a/src/main/java/tigase/server/StanzaSourceChecker.java
+++ b/src/main/java/tigase/server/StanzaSourceChecker.java
@@ -1,0 +1,50 @@
+/*
+ * Tigase XMPP Server - The instant messaging server
+ * Copyright (C) 2004 Tigase, Inc. (office@tigase.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. Look for COPYING file in the top folder.
+ * If not, see http://www.gnu.org/licenses/.
+ */
+
+package tigase.server;
+
+import tigase.kernel.beans.Bean;
+import tigase.kernel.beans.Inject;
+import tigase.kernel.core.Kernel;
+import tigase.server.xmppclient.ClientConnectionManager;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Bean(name = "stanza-source-checker", parent = Kernel.class, active = true, exportable = true)
+public class StanzaSourceChecker {
+
+	@Inject(nullAllowed = true)
+	private Set<ClientConnectionManager> clientConnectionManagers;
+	private Set<String> clientConnectionManagersIds = new HashSet<>(3);
+
+	public void setClientConnectionManagers(Set<ClientConnectionManager> clientConnectionManagers) {
+		this.clientConnectionManagers = clientConnectionManagers;
+		if (clientConnectionManagers != null) {
+			this.clientConnectionManagersIds = clientConnectionManagers.stream()
+					.map(BasicComponent::getName)
+					.collect(Collectors.toSet());
+		}
+	}
+
+	public boolean isPacketFromConnectionManager(Packet packet) {
+		return packet.getPacketFrom() != null && packet.getPacketFrom().getLocalpart() != null &&
+				clientConnectionManagersIds.contains(packet.getPacketFrom().getLocalpart());
+	}
+}

--- a/src/main/java/tigase/server/xmppclient/ClientConnectionManager.java
+++ b/src/main/java/tigase/server/xmppclient/ClientConnectionManager.java
@@ -215,6 +215,12 @@ public class ClientConnectionManager
 			if (p.getStanzaFrom() != null) {
 				p.initVars(null, p.getStanzaTo());
 			}
+			if (serv.getAuthorisedUserJid().isPresent()) {
+				p.setServerAuthorisedStanzaFrom(serv.getAuthorisedUserJid().get());
+
+				// In the future, in version 9.0.0, after resolving issue with cluster packet duplication,
+				// we should stamp stanza directly
+			}
 
 			// p.setPacketFrom(getFromAddress(id));
 			p.setPacketFrom(id);

--- a/src/main/java/tigase/xmpp/XMPPIOService.java
+++ b/src/main/java/tigase/xmpp/XMPPIOService.java
@@ -342,7 +342,7 @@ public class XMPPIOService<RefObject>
 	@Deprecated
 	@TigaseDeprecated(removeIn = "9.0.0", since = "8.2.0", note = "#getAuthorisedUserJid should be used instead")
 	public String getUserJid() {
-		return getAuthorisedUserJid().isPresent() ? getAuthorisedUserJid().get().toString() : null;
+		return getAuthorisedUserJid().map(JID::toString).orElse(null);
 	}
 
 	@Deprecated

--- a/src/main/java/tigase/xmpp/XMPPIOService.java
+++ b/src/main/java/tigase/xmpp/XMPPIOService.java
@@ -17,6 +17,7 @@
  */
 package tigase.xmpp;
 
+import tigase.annotations.TigaseDeprecated;
 import tigase.net.IOService;
 import tigase.server.ConnectionManager;
 import tigase.server.Packet;
@@ -26,10 +27,12 @@ import tigase.util.stringprep.TigaseStringprepException;
 import tigase.xml.Element;
 import tigase.xml.SimpleParser;
 import tigase.xml.SingletonFactory;
+import tigase.xmpp.jid.JID;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentSkipListMap;
@@ -74,7 +77,7 @@ public class XMPPIOService<RefObject>
 	protected XMPPIOProcessor[] processors = null;
 	private XMPPDomBuilderHandler<RefObject> domHandler = null;
 	private boolean firstPacket = true;
-	private String jid = null;
+	private JID authorisedUserJid = null;
 	/**
 	 * This variable keeps the time of last received XMPP packet, it is used to help detect dead connections.
 	 */
@@ -266,7 +269,7 @@ public class XMPPIOService<RefObject>
 
 	@Override
 	public String toString() {
-		return "jid: " + jid + ", " + super.toString();
+		return "jid: " + authorisedUserJid + ", " + super.toString();
 	}
 
 	public void writeRawData(String data) throws IOException {
@@ -328,12 +331,24 @@ public class XMPPIOService<RefObject>
 		return totalPacketsSent;
 	}
 
-	public String getUserJid() {
-		return this.jid;
+	public Optional<JID> getAuthorisedUserJid() {
+		return Optional.ofNullable(authorisedUserJid);
 	}
 
+	public void setAuthorisedUserJid(JID authorisedUserJid) {
+		this.authorisedUserJid = authorisedUserJid;
+	}
+
+	@Deprecated
+	@TigaseDeprecated(removeIn = "9.0.0", since = "8.2.0", note = "#getAuthorisedUserJid should be used instead")
+	public String getUserJid() {
+		return getAuthorisedUserJid().isPresent() ? getAuthorisedUserJid().get().toString() : null;
+	}
+
+	@Deprecated
+	@TigaseDeprecated(removeIn = "9.0.0", since = "8.2.0", note = "#setAuthorisedUserJid should be used instead")
 	public void setUserJid(String jid) {
-		this.jid = jid;
+		this.authorisedUserJid = JID.jidInstanceNS(jid);
 	}
 
 	public Map<String, Packet> getWaitingForAct() {

--- a/src/main/java/tigase/xmpp/impl/BindResource.java
+++ b/src/main/java/tigase/xmpp/impl/BindResource.java
@@ -24,6 +24,7 @@ import tigase.kernel.beans.config.ConfigField;
 import tigase.server.BasicComponent;
 import tigase.server.Iq;
 import tigase.server.Packet;
+import tigase.server.StanzaSourceChecker;
 import tigase.server.xmppclient.ClientConnectionManager;
 import tigase.server.xmppsession.SessionManager;
 import tigase.util.dns.DNSResolverFactory;
@@ -32,10 +33,7 @@ import tigase.xml.Element;
 import tigase.xmpp.*;
 import tigase.xmpp.jid.JID;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Queue;
+import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -67,9 +65,8 @@ public class BindResource
 	private static final Element[] DISCO_FEATURES = {new Element("feature", new String[]{"var"}, new String[]{XMLNS})};
 	private static final String RESOURCE_PREFIX_DEF = "tigase-";
 	private static int resGenerator = 0;
-	@Inject(nullAllowed = true)
-	private List<ClientConnectionManager> clientConnectionManagers;
-	private List<String> clientConnectionManagersIds = new ArrayList<>();
+	@Inject
+	private StanzaSourceChecker stanzaSourceChecker;
 	private String resourceDefPrefix = RESOURCE_PREFIX_DEF;
 	@ConfigField(desc = "Automatic resource assignment prefix", alias = DEF_RESOURCE_PREFIX_PROP_KEY)
 	private String resourcePrefix = null;
@@ -91,8 +88,7 @@ public class BindResource
 			packet.initVars(packet.getServerAuthorisedStanzaFrom().get(), packet.getStanzaTo());
 			return false;
 		}
-		if (session == null && packet.getPacketFrom() != null && packet.getPacketFrom().getLocalpart() != null &&
-				clientConnectionManagersIds.contains(packet.getPacketFrom().getLocalpart())) {
+		if (session == null && stanzaSourceChecker.isPacketFromConnectionManager(packet)) {
 			// rationale: packets coming from clients connections and arriving without existing session are most
 			// likely send after the session has been already closed and if we don't have correct JID
 			// to stamp (neither from packet itself nor from the session that doesn't exists)
@@ -244,15 +240,6 @@ public class BindResource
 		this.resourcePrefix = resourcePrefix;
 		this.resourceDefPrefix = Math.abs(DNSResolverFactory.getInstance().getDefaultHost().hashCode()) + "-" +
 				(this.resourcePrefix != null ? this.resourcePrefix : resourceDefPrefix);
-	}
-
-	public void setClientConnectionManagers(List<ClientConnectionManager> clientConnectionManagers) {
-		this.clientConnectionManagers = clientConnectionManagers;
-		if (clientConnectionManagers != null) {
-			this.clientConnectionManagersIds = clientConnectionManagers.stream()
-					.map(BasicComponent::getName)
-					.collect(Collectors.toList());
-		}
 	}
 
 	@Override


### PR DESCRIPTION
Improve stamping incomming stanzas with correct `from` attribute by involving ConnectionManager directly to avoid possible issues with missing `from` attributes due to race conditions; this is a temporary solution; #server-1271