### PR TITLE
Stamp outgoing packets in ClientConnectionManager with correct `to` t…

### DIFF
--- a/src/main/java/tigase/server/xmppclient/StreamManagementIOProcessor.java
+++ b/src/main/java/tigase/server/xmppclient/StreamManagementIOProcessor.java
@@ -248,6 +248,10 @@ public class StreamManagementIOProcessor
 			return false;
 		}
 
+		if (service.getAuthorisedUserJid().isPresent() && packet.getStanzaTo() == null) {
+			packet.initVars(packet.getStanzaFrom(), (JID)service.getAuthorisedUserJid().get());
+		}
+
 		OutQueue outQueue = (OutQueue) service.getSessionData().get(OUT_COUNTER_KEY);
 		if (outQueue == null) {
 			OutQueue.Entry e = new OutQueue.Entry(packet);

--- a/src/main/java/tigase/server/xmppclient/StreamManagementIOProcessor.java
+++ b/src/main/java/tigase/server/xmppclient/StreamManagementIOProcessor.java
@@ -719,7 +719,6 @@ public class StreamManagementIOProcessor
 					return false;
 				}
 
-				// we do this check if queue is bigger than 30 as some client confirm after X stanzas (not after each one)
 				if (shouldCheckTimeout()) {
 					Entry first = queue.peekFirst();
 					if (first != null && (System.currentTimeMillis() - first.stamp > ((long)timeoutInSec * 1000))) {

--- a/src/main/java/tigase/xmpp/XMPPIOService.java
+++ b/src/main/java/tigase/xmpp/XMPPIOService.java
@@ -125,6 +125,9 @@ public class XMPPIOService<RefObject>
 			log.log(Level.FINEST, "Added packet to send: {1} [{0}]", new Object[]{toString(), packet});
 		}
 
+		if (getAuthorisedUserJid().isPresent() && packet.getStanzaTo() == null) {
+			packet.initVars(packet.getStanzaFrom(), getAuthorisedUserJid().get());
+		}
 		// processing packet using io level processors
 		if (processors != null) {
 			for (XMPPIOProcessor processor : processors) {

--- a/src/main/java/tigase/xmpp/XMPPIOService.java
+++ b/src/main/java/tigase/xmpp/XMPPIOService.java
@@ -125,9 +125,6 @@ public class XMPPIOService<RefObject>
 			log.log(Level.FINEST, "Added packet to send: {1} [{0}]", new Object[]{toString(), packet});
 		}
 
-		if (getAuthorisedUserJid().isPresent() && packet.getStanzaTo() == null) {
-			packet.initVars(packet.getStanzaFrom(), getAuthorisedUserJid().get());
-		}
 		// processing packet using io level processors
 		if (processors != null) {
 			for (XMPPIOProcessor processor : processors) {


### PR DESCRIPTION
…o handle cases if it has to be returned and we would have to create return packet with correct `from`; #server-1188