### PR TITLE
Always add `from` to presence packets to avoid issues with delivery

### DIFF
--- a/src/main/java/tigase/xmpp/impl/PresenceAbstract.java
+++ b/src/main/java/tigase/xmpp/impl/PresenceAbstract.java
@@ -31,6 +31,7 @@ import tigase.xmpp.jid.BareJID;
 import tigase.xmpp.jid.JID;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.Queue;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -182,6 +183,8 @@ public abstract class PresenceAbstract
 	 * @return an instance of {@link Packet} holding Presence stanza created from provided parameters.
 	 */
 	public static Packet sendPresence(StanzaType t, JID from, JID to, Queue<Packet> results, Element pres) {
+		Objects.requireNonNull(from);
+		Objects.requireNonNull(to);
 		Element presence = null;
 		Packet result = null;
 
@@ -466,11 +469,11 @@ public abstract class PresenceAbstract
 					if (log.isLoggable(Level.FINEST)) {
 						log.log(Level.FINEST, session.getBareJID() + " | Sending presence probe to: " + buddy);
 					}
-					sendPresence(null, null, buddy, results, presProbe);
+					sendPresence(null, session.getBareJID(), buddy.getBareJID(), results, presProbe);
 					if (log.isLoggable(Level.FINEST)) {
-						log.log(Level.FINEST, session.getBareJID() + " | Sending intial presence to: " + buddy);
+						log.log(Level.FINEST, session.getBareJID() + " | Sending initial presence to: " + buddy);
 					}
-					sendPresence(null, null, buddy, results, presInit);
+					sendPresence(null, session.getBareJID(), buddy.getBareJID(), results, presInit);
 					roster_util.setPresenceSent(session, buddy, true);
 				} else {
 					if (log.isLoggable(Level.FINEST)) {
@@ -495,7 +498,7 @@ public abstract class PresenceAbstract
 					if (log.isLoggable(Level.FINEST)) {
 						log.log(Level.FINEST, session.getBareJID() + " | Sending probe to: " + buddy);
 					}
-					sendPresence(null, null, buddy, results, presProbe);
+					sendPresence(null, session.getBareJID(), buddy.getBareJID(), results, presProbe);
 				} else {
 					if (log.isLoggable(Level.FINEST)) {
 						log.log(Level.FINEST, session.getBareJID() + " | Skipping sending presence probe to: " + buddy);
@@ -520,7 +523,7 @@ public abstract class PresenceAbstract
 					if (log.isLoggable(Level.FINEST)) {
 						log.log(Level.FINEST, session.getBareJID() + " | Sending initial presence to: " + buddy);
 					}
-					sendPresence(null, null, buddy, results, presInit);
+					sendPresence(null, session.getBareJID(), buddy.getBareJID(), results, presInit);
 					roster_util.setPresenceSent(session, buddy, true);
 				} else {
 					if (log.isLoggable(Level.FINEST)) {

--- a/src/main/java/tigase/xmpp/impl/PresenceState.java
+++ b/src/main/java/tigase/xmpp/impl/PresenceState.java
@@ -707,13 +707,8 @@ public class PresenceState
 					Element pres = conn.getPresence();
 
 					if (pres != null) {
-						JID to;
-						if (probeFullJID) {
-							to = packet.getStanzaFrom();
-						} else {
-							to = packet.getStanzaFrom().copyWithoutResource();
-						}
-						sendPresence(null, null, to, results, pres);
+						JID to = probeFullJID ? packet.getStanzaFrom(): packet.getStanzaFrom().copyWithoutResource();
+						sendPresence(null, conn.getJID(), to, results, pres);
 						roster_util.setPresenceSent(session, packet.getStanzaFrom(), true);
 						if (log.isLoggable(Level.FINEST)) {
 							log.log(Level.FINEST, "Received probe, sending presence response to: {0}", to);
@@ -751,7 +746,7 @@ public class PresenceState
 					Element pres = conn.getPresence();
 
 					if (pres != null) {
-						sendPresence(null, null, packet.getStanzaFrom(), results, pres);
+						sendPresence(null, conn.getJID(), packet.getStanzaFrom(), results, pres);
 						if (log.isLoggable(Level.FINEST)) {
 							log.log(Level.FINEST, "Received probe, sending presence response to: {0}",
 									packet.getStanzaFrom());
@@ -903,7 +898,7 @@ public class PresenceState
 			Element pres = session.getPresence();
 
 			if (pres != null) {
-				sendPresence(null, null, buddy, results, pres);
+				sendPresence(null, session.getJID(), buddy, results, pres);
 				roster_util.setPresenceSent(session, buddy, true);
 			}
 		}

--- a/src/main/java/tigase/xmpp/impl/PresenceSubscription.java
+++ b/src/main/java/tigase/xmpp/impl/PresenceSubscription.java
@@ -327,7 +327,7 @@ public class PresenceSubscription
 			if (delay != null) {
 				// offline packet, lets send probe
 				Element presProbe = prepareProbe(session);
-				sendPresence(null, null, packet.getStanzaFrom(), results, presProbe);
+				sendPresence(null, session.getJID(), packet.getStanzaFrom(), results, presProbe);
 			}
 
 		}


### PR DESCRIPTION
Always add `from` to presence packets to avoid issues with delivery; add requirement for from/to attribute in sendPresence() method ; #server-1311