### PR TITLE
Return an error if offline message was not stored due to internal error #server-1355

### DIFF
--- a/src/main/java/tigase/db/MsgRepositoryIfc.java
+++ b/src/main/java/tigase/db/MsgRepositoryIfc.java
@@ -35,9 +35,9 @@ import java.util.concurrent.locks.ReentrantLock;
 public interface MsgRepositoryIfc<T extends DataSource>
 		extends OfflineMsgRepositoryIfc, DataSourceAware<T> {
 
-	Map<Enum, Long> getMessagesCount(JID to) throws UserNotFoundException;
+	Map<Enum, Long> getMessagesCount(JID to) throws UserNotFoundException, TigaseDBException;
 
-	List<Element> getMessagesList(JID to) throws UserNotFoundException;
+	List<Element> getMessagesList(JID to) throws UserNotFoundException, TigaseDBException;
 
 	@TigaseDeprecated(since = "8.2.0", removeIn = "9.0.0")
 	@Deprecated
@@ -45,7 +45,7 @@ public interface MsgRepositoryIfc<T extends DataSource>
 
 	Queue<Element> loadMessagesToJID(List<String> db_ids, XMPPResourceConnection session,
 													 boolean delete, MsgRepository.OfflineMessagesProcessor proc)
-			throws UserNotFoundException;
+			throws UserNotFoundException, TigaseDBException;
 
 	int deleteMessagesToJID(List<String> db_ids, XMPPResourceConnection session)
 			throws UserNotFoundException;

--- a/src/main/java/tigase/db/OfflineMsgRepositoryIfc.java
+++ b/src/main/java/tigase/db/OfflineMsgRepositoryIfc.java
@@ -62,7 +62,7 @@ public interface OfflineMsgRepositoryIfc
 	 * @return a {@link Queue} of {@link Element} objects representing stored payloads for the given user's {@link JID}
 	 *
 	 */
-	Queue<Element> loadMessagesToJID(XMPPResourceConnection session, boolean delete) throws UserNotFoundException;
+	Queue<Element> loadMessagesToJID(XMPPResourceConnection session, boolean delete) throws UserNotFoundException, TigaseDBException;
 
 	/**
 	 * Saves the massage to the repository
@@ -78,5 +78,5 @@ public interface OfflineMsgRepositoryIfc
 	 *
 	 */
 	boolean storeMessage(JID from, JID to, Date expired, Element msg, NonAuthUserRepository userRepo)
-			throws UserNotFoundException;
+			throws UserNotFoundException, TigaseDBException;
 }

--- a/src/main/java/tigase/server/amp/db/MsgRepository.java
+++ b/src/main/java/tigase/server/amp/db/MsgRepository.java
@@ -384,7 +384,7 @@ public abstract class MsgRepository<T, S extends DataSource>
 
 		@Override
 		public Queue<Element> loadMessagesToJID(XMPPResourceConnection session, boolean delete)
-				throws UserNotFoundException {
+				throws UserNotFoundException, TigaseDBException {
 			Queue<Element> result = null;
 			try {
 				MsgRepositoryIfc repo = getRepository(session.getBareJID().getDomain());
@@ -397,7 +397,7 @@ public abstract class MsgRepository<T, S extends DataSource>
 
 		@Override
 		public boolean storeMessage(JID from, JID to, Date expired, Element msg, NonAuthUserRepository userRepo)
-				throws UserNotFoundException {
+				throws UserNotFoundException, TigaseDBException {
 			MsgRepositoryIfc repo = getRepository(to.getDomain());
 			boolean result = repo.storeMessage(from, to, expired, msg, userRepo);
 			if (result && expired != null) {
@@ -415,12 +415,12 @@ public abstract class MsgRepository<T, S extends DataSource>
 		}
 
 		@Override
-		public Map<Enum, Long> getMessagesCount(JID to) throws UserNotFoundException {
+		public Map<Enum, Long> getMessagesCount(JID to) throws UserNotFoundException, TigaseDBException {
 			return getRepository(to.getDomain()).getMessagesCount(to);
 		}
 
 		@Override
-		public List<Element> getMessagesList(JID to) throws UserNotFoundException {
+		public List<Element> getMessagesList(JID to) throws UserNotFoundException, TigaseDBException {
 			return getRepository(to.getDomain()).getMessagesList(to);
 		}
 
@@ -436,7 +436,7 @@ public abstract class MsgRepository<T, S extends DataSource>
 
 		@Override
 		public Queue<Element> loadMessagesToJID(List db_ids, XMPPResourceConnection session, boolean delete,
-												OfflineMessagesProcessor proc) throws UserNotFoundException {
+												OfflineMessagesProcessor proc) throws UserNotFoundException, TigaseDBException {
 			return getRepository(session.getDomainAsJID().getDomain()).loadMessagesToJID(db_ids, session, delete, proc);
 		}
 

--- a/src/main/java/tigase/xmpp/impl/FlexibleOfflineMessageRetrieval.java
+++ b/src/main/java/tigase/xmpp/impl/FlexibleOfflineMessageRetrieval.java
@@ -19,6 +19,7 @@ package tigase.xmpp.impl;
 
 import tigase.db.MsgRepositoryIfc;
 import tigase.db.NonAuthUserRepository;
+import tigase.db.TigaseDBException;
 import tigase.db.UserNotFoundException;
 import tigase.kernel.beans.Bean;
 import tigase.kernel.beans.Inject;
@@ -158,7 +159,7 @@ public class FlexibleOfflineMessageRetrieval
 					} else if (purge && !fetch) {
 						msg_repo.deleteMessagesToJID(null, session);
 					}
-				} catch (UserNotFoundException | NotAuthorizedException ex) {
+				} catch (TigaseDBException | NotAuthorizedException ex) {
 					log.log(Level.WARNING, "Problem retrieving messages from repository: ", ex);
 				}
 				results.offer(packet.okResult(query, 0));
@@ -213,6 +214,8 @@ public class FlexibleOfflineMessageRetrieval
 					}
 				} catch (UserNotFoundException | NotAuthorizedException ex) {
 					log.log(Level.WARNING, "Problem retrieving messages from repository: ", ex);
+				} catch (TigaseDBException ex) {
+					results.offer(Authorization.INTERNAL_SERVER_ERROR.getResponseMessage(packet, null, true));
 				}
 			}
 		}
@@ -220,7 +223,7 @@ public class FlexibleOfflineMessageRetrieval
 
 	public Queue<Packet> restorePacketForOffLineUser(List<String> db_ids, XMPPResourceConnection conn,
 													 MsgRepositoryIfc repo)
-			throws UserNotFoundException, NotAuthorizedException {
+			throws UserNotFoundException, NotAuthorizedException, TigaseDBException {
 		Queue<Element> elems = repo.loadMessagesToJID(db_ids, conn, false, offlineMessagesStamper);
 
 		if (elems != null) {
@@ -297,7 +300,7 @@ public class FlexibleOfflineMessageRetrieval
 
 		} catch (NotAuthorizedException ex) {
 			log.log(Level.WARNING, "Problem retrieving messages from repository: ", ex);
-		} catch (UserNotFoundException ex) {
+		} catch (TigaseDBException ex) {
 
 		}
 	}
@@ -309,7 +312,7 @@ public class FlexibleOfflineMessageRetrieval
 			if (null != messagesList && !messagesList.isEmpty()) {
 				query.addChildren(messagesList);
 			}
-		} catch (NotAuthorizedException | UserNotFoundException ex) {
+		} catch (NotAuthorizedException | TigaseDBException ex) {
 			log.log(Level.WARNING, "Problem retrieving messages from repository: ", ex);
 		}
 	}

--- a/src/test/java/tigase/server/amp/db/AbstractMsgRepositoryTest.java
+++ b/src/test/java/tigase/server/amp/db/AbstractMsgRepositoryTest.java
@@ -61,7 +61,7 @@ public abstract class AbstractMsgRepositoryTest<DS extends DataSource, T>
 	
 	@Test
 	public void testStorageOfOfflineMessage()
-			throws UserNotFoundException, NotAuthorizedException, TigaseStringprepException {
+			throws TigaseDBException, NotAuthorizedException, TigaseStringprepException {
 		List<Packet> messages = new ArrayList<>();
 		for (int i = 0; i < 5; i++) {
 			Packet message = Message.getMessage(sender, recipient, StanzaType.chat, generateRandomBody(), null, null,
@@ -131,7 +131,7 @@ public abstract class AbstractMsgRepositoryTest<DS extends DataSource, T>
 
 	@Test
 	public void testStorageOfOfflineMessageWithExpiration1()
-			throws UserNotFoundException, NotAuthorizedException, TigaseStringprepException {
+			throws TigaseDBException, NotAuthorizedException, TigaseStringprepException {
 		try {
 			Date expire = new Date(System.currentTimeMillis() - 60 * 1000);
 


### PR DESCRIPTION
I'm not sure if that is OK, as we are making changes to a few methods of the API (changed thrown errors). Please review and decided if it is OK or we need to find other way to fix this issue, but I think we should keep it this way.